### PR TITLE
Add new command list-unicode-display-popup

### DIFF
--- a/list-unicode-display.el
+++ b/list-unicode-display.el
@@ -83,16 +83,18 @@ some time."
 
     (setq char-alist (sort char-alist cmp))
 
-    (with-current-buffer (get-buffer-create "*Unicode Characters*")
-      (let ((inhibit-read-only t))
-        (erase-buffer)
-        (dolist (c char-alist)
-          (insert (format "0x%06X\t" (cdr c)))
-          (insert (char-to-string (cdr c)))
-          (insert (format "\t%s\n" (car c))))
-        (list-unicode-display-mode)
-        (goto-char (point-min))
-        (switch-to-buffer (current-buffer))))))
+    (let ((buf (get-buffer-create "*Unicode Characters*"))
+          (display-buffer-base-action '(display-buffer-same-window . nil)))
+      (with-current-buffer buf
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (dolist (c char-alist)
+            (insert (format "0x%06X\t" (cdr c)))
+            (insert (char-to-string (cdr c)))
+            (insert (format "\t%s\n" (car c))))
+          (list-unicode-display-mode)
+          (goto-char (point-min))))
+      (display-buffer buf))))
 
 (provide 'list-unicode-display)
 ;;; list-unicode-display.el ends here


### PR DESCRIPTION
Hi, this PR adds a new command `list-unicode-display-popup`, which launches the list of symbols buffer in a new popup window instead of the current buffer (controlled by the new custom var `list-unicode-display-popup-display-action`).

I've also created a new function `list-unicode-display--create-buffer` to dedupe repeated logic between `list-unicode-display` and `list-unicode-display-popup`.

![unicode-popup](https://user-images.githubusercontent.com/17688577/217479444-f484f478-6b19-42bf-89bb-dc2a4048a4c0.png)

Let me know what you think, thanks!