### PR TITLE
Create command for copying a prompted character to the kill ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Otherwise:
 
     M-x list-unicode-display
 
-<hr>
-
 Alternatively, `list-unicode-display-find-copy` may be used to search
 interactively for a character and copy it to the kill ring.
+
+<hr>
 
 
 [💝 Support this project and my other Open Source work](https://www.patreon.com/sanityinc)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Otherwise:
 
 <hr>
 
+Alternatively, `list-unicode-display-find-copy` may be used to search
+interactively for a character via `completing-read` and copy it straight
+to the kill ring.
+
 
 [💝 Support this project and my other Open Source work](https://www.patreon.com/sanityinc)
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Otherwise:
 <hr>
 
 Alternatively, `list-unicode-display-find-copy` may be used to search
-interactively for a character via `completing-read` and copy it straight
-to the kill ring.
+interactively for a character and copy it to the kill ring.
 
 
 [💝 Support this project and my other Open Source work](https://www.patreon.com/sanityinc)

--- a/list-unicode-display.el
+++ b/list-unicode-display.el
@@ -104,7 +104,7 @@ some time."
 Also see `insert-char', which is similar to this command, but inserts the
 character instead."
   (interactive)
-  (kill-new (char-to-string (read-char-by-name ""))))
+  (kill-new (char-to-string (read-char-by-name "Copy char: "))))
 
 (provide 'list-unicode-display)
 ;;; list-unicode-display.el ends here

--- a/list-unicode-display.el
+++ b/list-unicode-display.el
@@ -34,6 +34,12 @@
 (define-derived-mode list-unicode-display-mode help-mode "Unicode Characters"
   "Major mode to display a list of unicode characters.")
 
+(defface list-unicode-display-code-point
+  '((t :foreground "light green"
+       :weight bold))
+  "Face for unicode code points."
+  :group 'list-unicode-display)
+
 (defun list-unicode-display-describe ()
   "Apply `describe-char' to the character in a row of a `list-unicode-display-mode' buffer."
   (interactive)
@@ -52,6 +58,25 @@
     (message "Saved `%s' to the kill-ring."
              (buffer-substring-no-properties (point) (1+ (point))))))
 
+(defun list-unicode-display--hashtables ()
+  "Return a cons cell of hastables for working with unicode data.
+
+The car is the output of the function `ucs-names', and the cdr is the a
+hashtable mapping unicode names to char values."
+  ;; alist like ("name" . code-point)
+  (let* ((char-alist ()))
+    (let ((names (ucs-names)))
+      (if (hash-table-p names)
+          ;; ucs-names returns a hash table in emacs 26+
+          (maphash (lambda (name char)
+                     (push (cons name char) char-alist))
+                   names)
+        (mapc (lambda (pair)
+                (push pair char-alist))
+              names))
+      (cons names char-alist))))
+
+;;;###autoload
 (define-key list-unicode-display-mode-map (kbd "RET") #'list-unicode-display-describe)
 (define-key list-unicode-display-mode-map (kbd "w") #'list-unicode-display-copy)
 (define-key list-unicode-display-mode-map (kbd "g") #'list-unicode-display)
@@ -62,24 +87,11 @@
 If no regexp is supplied, all characters are shown.  This takes
 some time."
   (interactive "sRegexp (default \".*\"): ")
-  (let* ((regexp (or regexp ".*"))
-         (case-fold-search t)
-         (cmp (lambda (x y) (< (cdr x) (cdr y))))
-         (pred (lambda (name) (string-match-p regexp name)))
-         ;; alist like ("name" . code-point)
-         (char-alist ()))
-
-    (let ((names (ucs-names)))
-      (if (hash-table-p names)
-          ;; ucs-names returns a hash table in emacs 26+
-          (maphash (lambda (name char)
-                     (when (funcall pred name)
-                       (push (cons name char) char-alist)))
-                   names)
-        (mapc (lambda (pair)
-                (when (funcall pred (car pair))
-                  (push pair char-alist)))
-              names)))
+  (pcase-let* ((`(,names . ,char-alist) (list-unicode-display--hashtables))
+               (regexp (or regexp ".*"))
+               (case-fold-search t)
+               (cmp (lambda (x y) (< (cdr x) (cdr y))))
+               (pred (lambda (name) (string-match-p regexp name))))
 
     (setq char-alist (sort char-alist cmp))
 
@@ -95,6 +107,34 @@ some time."
           (list-unicode-display-mode)
           (goto-char (point-min))))
       (display-buffer buf))))
+
+
+;;;###autoload
+(defun list-unicode-display-find-copy ()
+  "Copy a prompted character to the kill ring."
+  (interactive)
+  (pcase-let ((`(,names . ,char-alist) (list-unicode-display--hashtables)))
+    (let ((completion-extra-properties
+           `(:affixation-function
+             ,(lambda (completions)
+                (let ((max-name-width (if (null completions)
+                                          0
+                                        (seq-max (mapcar #'length completions)))))
+                  (mapcar (lambda (name)
+                            (let* ((char (alist-get name char-alist nil nil #'string=))
+                                   (char-hex (format "%03X" char))
+                                   (unicode-point (concat "U+" char-hex)))
+                              (list name
+                                    ""
+                                    (format "%s  %s %s %s"
+                                            (make-string (- max-name-width (length name)) ?\s)
+                                            (propertize unicode-point 'face 'list-unicode-display-code-point)
+                                            ;; Max unicode code point is U+10FFFF
+                                            (make-string (- 6 (length char-hex)) ?\s)
+                                            (char-to-string char)))))
+                          completions))))))
+      (kill-new (char-to-string
+                 (alist-get (completing-read "Find: " names) char-alist nil nil #'string=))))))
 
 (provide 'list-unicode-display)
 ;;; list-unicode-display.el ends here


### PR DESCRIPTION
Hi, I find that my biggest use case for `list-unicode-display` was searching for a character and then copying it straight to kill ring, so I thought it might be helpful to create a utility command for doing this using `completing-read`:

![list-unicode-display-completing-read](https://github.com/user-attachments/assets/6d8f3dde-345f-4209-b397-d1aaff4b8a5e)

The search is along the character name, though I also show the unicode code point and the symbol itself via `:affixation-function`.

I extracted some common functionality between the new command `list-unicode-display-find-copy` and the existing `list-unicode-display` to a new function `list-unicode-display--hashtables`, so the diff is a little bigger than it would be otherwise.

Let me know what you think, thanks!